### PR TITLE
Fixes this error message: 

### DIFF
--- a/lib/cloudfront-invalidator.rb
+++ b/lib/cloudfront-invalidator.rb
@@ -1,4 +1,4 @@
-require 'net/http'
+require 'net/https'
 require 'base64'
 require 'hmac-sha1'
 


### PR DESCRIPTION
NoMethodError: undefined method `use_ssl=' for #<Net::HTTP cloudfront.amazonaws.com:443 open=false>
